### PR TITLE
Move the public directory 

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -469,14 +469,17 @@ Builder.prototype._configReplacePatterns = function() {
 
 Builder.prototype.publicTree = function() {
   var trees = this.addonTreesFor('public');
+  var self = this;
 
   if (this.trees.public) {
     trees.push(this.trees.public);
   }
 
-  return mergeTrees(trees, {
+  return rename(mergeTrees(trees, {
     overwrite: true,
     description: 'TreeMerge (public)'
+  }), function(relativePath) {
+    return self.name + '/' + relativePath;
   });
 };
 


### PR DESCRIPTION
Move the public directory into the named folder as you may have N types of builds
