### PR TITLE
Adds the test-support hook for addons

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -213,12 +213,12 @@ Builder.prototype._contentForAppBoot = function(content, config) {
   content.push('if (runningTests) {');
   content.push('  require("' +
     config.modulePrefix +
-    '/tests/test-helper");');
+    '-tests/index");');
   if (this.options.autoRun) {
     content.push('} else {');
     content.push('  require("' +
       config.modulePrefix +
-      '/app")["default"].create(' +
+      '/index")["default"].create(' +
       calculateAppConfig(config) +
       ');');
   }
@@ -242,6 +242,28 @@ Builder.prototype.testIndex = function() {
     env: 'test',
     patterns: this._configReplacePatterns()
   });
+};
+
+Builder.prototype.testFiles = function() {
+  var testemTree = unwatchedTree(path.join(__dirname, '..', 'node_modules/ember-cli/lib/broccoli'));
+  var testSupportPath = this.options.outputPaths.testSupport.js;
+  testSupportPath = testSupportPath.testSupport || testSupportPath;
+
+  var testem = funnel(testemTree, {
+    files: ['testem.js'],
+    destDir: this.name + '-tests/'
+  });
+
+  var testSupport = funnel(testSupportPath);
+
+  if (this.options.fingerprint && this.options.fingerprint.exclude) {
+    this.options.fingerprint.exclude.push('testem');
+  }
+
+  return [
+    testem,
+    testSupport
+  ];
 };
 
 Builder.prototype.index = function() {
@@ -369,7 +391,10 @@ Builder.prototype.addonJavascript = function() {
 };
 
 Builder.prototype._processedTestsTree = function() {
-  return mv(this.trees.tests, this.name + '-tests');
+    var testSupport = this.addonTreesFor('test-support').map(function(tree) {
+      return mv(tree, '/test-support');
+    }, this);
+  return mv(mergeTrees(testSupport.concat(this.trees.tests)), this.name + '-tests');
 };
 
 Builder.prototype.appTests = function() {
@@ -377,6 +402,7 @@ Builder.prototype.appTests = function() {
 
   if (this.tests) {
     var tests = this._processedTestsTree();
+
     var preprocessedTests = preprocessJs(tests, '/tests', this.name + '-tests', {
       registry: this.registry
     });
@@ -435,8 +461,7 @@ Builder.prototype.javascript = function() {
   jsTrees = jsTrees.concat(
     appJavascript,
     this.appTests(),
-    this.addonJavascript(),
-    packagerFiles
+    this.addonJavascript()
   );
 
   return jsTrees.map(function(tree) {
@@ -451,7 +476,7 @@ Builder.prototype.javascript = function() {
         }
       }
     );
-  }, this);
+  }, this).concat(packagerFiles);
 };
 
 Builder.prototype._configReplacePatterns = function() {
@@ -521,7 +546,7 @@ Builder.prototype.toArray = function() {
   ];
 
   if (this.tests) {
-    sourceTrees = sourceTrees.concat(this.testIndex());
+    sourceTrees = sourceTrees.concat(this.testIndex(), this.testFiles());
   }
 
   return sourceTrees;


### PR DESCRIPTION
This is introducing backwards compatibility for the `treeForTestSupport` hook.
