### PR TITLE
Remove unnecessary renames

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -231,10 +231,7 @@ Builder.prototype.dependencies = function(pkg) {
 
 Builder.prototype.testIndex = function() {
   var testIndexPath = this.name + '-tests/';
-
-  var index = rename(this.trees.tests, function(relativePath) {
-    return relativePath === 'index.html' ? testIndexPath + relativePath : relativePath;
-  });
+  var index = mv(this.trees.tests, testIndexPath);
 
   return configReplace(index, this._configTree(), {
     configPath: path.join(this.name, 'config', 'environments', 'test.json'),
@@ -274,13 +271,11 @@ Builder.prototype.index = function() {
 
   var self = this;
 
-  return rename(configReplace(index, this._configTree(), {
+  return mv(configReplace(index, this._configTree(), {
     configPath: path.join(this.name, 'config', 'environments', this.env + '.json'),
     files: [ htmlName ],
     patterns: this._configReplacePatterns()
-  }), function(relativePath) {
-    return self.name + '/' + relativePath;
-  });
+  }), self.name + '/');
 };
 
 Builder.prototype.addonTreesFor = function(type) {
@@ -496,18 +491,15 @@ Builder.prototype._configReplacePatterns = function() {
 
 Builder.prototype.publicTree = function() {
   var trees = this.addonTreesFor('public');
-  var self = this;
 
   if (this.trees.public) {
     trees.push(this.trees.public);
   }
 
-  return rename(mergeTrees(trees, {
+  return mv(mergeTrees(trees, {
     overwrite: true,
-    description: 'TreeMerge (public)'
-  }), function(relativePath) {
-    return self.name + '/' + relativePath;
-  });
+    description: 'TreeMerger (public)'
+  }), this.name + '/');
 };
 
 Builder.prototype.styles = function() {


### PR DESCRIPTION
Rename does forces the tree to iterated in it's entirety, where mv will terminate as soon as match occurs.
