### PR TITLE
Update Babel

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -14,7 +14,7 @@ var path = require('path');
 var unwatchedTree = require('broccoli-unwatched-tree');
 var configLoader = require('ember-cli/lib/broccoli/broccoli-config-loader');
 var configReplace = require('ember-cli/lib/broccoli/broccoli-config-replace');
-var ES6Modules = require('broccoli-es6modules');
+var babel = require('broccoli-babel-transpiler');
 var stew = require('broccoli-stew');
 var funnel = require('broccoli-funnel');
 var preprocessJs  = preprocessors.preprocessJs;
@@ -489,15 +489,11 @@ Builder.prototype.setAddonLoadPath = function(tree, name) {
 };
 
 Builder.prototype.transpileTree = function(tree) {
-  return new ES6Modules(tree, {
-    description: 'ES6: App Tree',
-    extensions: ['js'],
-    exportDepGraph: true,
-    esperantoOptions: {
-      absolutePaths: true,
-      strict: true,
-      _evilES3SafeReExports: this.options.es3Safe
-    }
+  return new babel(tree, {
+    modules: 'amdStrict',
+    exportModuleMetadata: true,
+    moduleIds: true,
+    sourceMaps: true
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "dependencies": {
     "broccoli-es3-safe-recast": "^2.0.0",
-    "broccoli-es6Modules": "git://github.com/chadhietala/broccoli-es6modules.git#gen-dep-graph",
+    "broccoli-babel-transpiler": "git://github.com/chadhietala/broccoli-babel-transpiler#dep-export",
     "broccoli-funnel": "^0.2.3",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-stew": "^0.2.1",

--- a/tests/acceptance/builder-acceptance-test.js
+++ b/tests/acceptance/builder-acceptance-test.js
@@ -49,7 +49,7 @@ describe('Acceptance: Builder', function() {
   it('addons should not override the consuming applications files if the same file exists', function () {
     builder = new Builder();
     var trees = builder.toTree();
-    build = new broccoli.Builder(mergeTrees(trees));
+    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var basePath = path.join(results.directory, 'dummy/components');
       var containsAddon = fs.readFileSync(path.join(basePath, 'foo-bar.js'), 'utf8').indexOf('fromAddon') > -1;
@@ -62,17 +62,27 @@ describe('Acceptance: Builder', function() {
   it('should have the index.html', function() {
     builder = new Builder();
     var trees = builder.toTree();
-    build = new broccoli.Builder(mergeTrees(trees));
+    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var files = walkSync(results.directory);
       expect(files.indexOf('dummy/index.html') > -1).to.be.eql(true);
     });
   });
 
+  it('should contain a dep-graph.json per tree', function() {
+    builder = new Builder();
+    var trees = builder.toTree();
+    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
+    return build.build().then(function(results) {
+      var files = walkSync(results.directory);
+      expect(files.indexOf('dep-graph.json') > -1).to.be.eql(true);
+    });
+  });
+
   it('should include ember from the addon directory', function () {
     builder = new Builder();
     var trees = builder.toTree();
-    build = new broccoli.Builder(mergeTrees(trees));
+    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var files = walkSync(results.directory);
       var folders = files.filter(function(item) {
@@ -87,7 +97,7 @@ describe('Acceptance: Builder', function() {
   it('should preprocess templates with an installed pre-processor', function () {
     builder = new Builder();
     var trees = builder.toTree();
-    build = new broccoli.Builder(mergeTrees(trees));
+    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var expected = fs.readFileSync(path.resolve('..', '..', 'expectations/templates/application.js'), 'utf8');
       var assertion = fs.readFileSync(results.directory + '/dummy/templates/application.js', 'utf8');
@@ -98,16 +108,19 @@ describe('Acceptance: Builder', function() {
   it('should contain tests if environment is development', function () {
     builder = new Builder();
     var trees = builder.toTree();
-    build = new broccoli.Builder(mergeTrees(trees));
+    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var files = walkSync(results.directory);
+
       var expectactions = [
         'dummy/tests/',
-        'dummy/tests/dep-graph.json',
+        'dummy/tests/index.html',
+        'dummy/tests/testem.js',
         'dummy/tests/unit/',
         'dummy/tests/unit/components/',
-        'dummy/tests/unit/components/foo-bar-test.js'
+        'dummy/tests/unit/components/foo-bar-test.js',
       ];
+
       expect(builder.env).to.eql('development');
       expectactions.forEach(function(file) {
         expect(files.indexOf(file) > -1).to.eql(true);
@@ -118,7 +131,7 @@ describe('Acceptance: Builder', function() {
   it('should contain the test index', function() {
     builder = new Builder();
     var trees = builder.toTree();
-    build = new broccoli.Builder(mergeTrees(trees));
+    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var files = walkSync(results.directory);
       expect(files.indexOf('dummy/tests/index.html') > -1).to.eql(true);
@@ -128,7 +141,7 @@ describe('Acceptance: Builder', function() {
   it('should not contain tests from the addon', function () {
     builder = new Builder();
     var trees = builder.toTree();
-    build = new broccoli.Builder(mergeTrees(trees));
+    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var files = walkSync(results.directory);
       var expectactions = [
@@ -147,7 +160,7 @@ describe('Acceptance: Builder', function() {
   it('should include styles', function() {
     builder = new Builder();
     var trees = builder.toTree();
-    build = new broccoli.Builder(mergeTrees(trees));
+    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var files = walkSync(results.directory);
       expect(files.indexOf('dummy/styles/foo.css') > -1).to.eql(true);
@@ -157,7 +170,7 @@ describe('Acceptance: Builder', function() {
   it('styles should have gone through the preprocessor', function() {
     builder = new Builder();
     var trees = builder.toTree();
-    build = new broccoli.Builder(mergeTrees(trees));
+    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var expected = fs.readFileSync(path.resolve('..', '..', 'expectations/styles/foo.css'), 'utf8');
       var assertion = fs.readFileSync(results.directory + '/dummy/styles/foo.css', 'utf8');

--- a/tests/expectations/templates/application.js
+++ b/tests/expectations/templates/application.js
@@ -1,7 +1,7 @@
-define('dummy/templates/application', ['exports', 'ember'], function (exports, Ember) {
+define("dummy/templates/application", ["exports", "ember"], function (exports, _ember) {
+  "use strict";
 
-	'use strict';
-
-	exports['default'] = Ember['default'].HypeBars.template("HYPE HYPE HYPE");
-
+  var foo = "foo";
+  exports.foo = foo;
+  exports["default"] = _ember["default"].HypeBars.template("HYPE HYPE HYPE");
 });

--- a/tests/fixtures/dummy/node_modules/ember-cli-hypebars/index.js
+++ b/tests/fixtures/dummy/node_modules/ember-cli-hypebars/index.js
@@ -16,7 +16,7 @@ HypeBars.prototype.constructor = HypeBars;
 HypeBars.prototype.extensions = ['hbs', 'handlebars'];
 HypeBars.prototype.targetExtension = 'js';
 HypeBars.prototype.processString = function() {
-  return 'import Ember from "ember";\nexport default Ember.HypeBars.template("HYPE HYPE HYPE");';
+  return 'import Ember from "ember"; export let foo = "foo"; \n export default Ember.HypeBars.template("HYPE HYPE HYPE");';
 };
 
 module.exports = {


### PR DESCRIPTION
This commit removes esperato in favor of Babel. It currently uses a fork and is waiting for https://github.com/babel/broccoli-babel-transpiler/pull/32 to be merged.
