### PR TITLE
Add amd name resolver

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -17,6 +17,7 @@ var configReplace = require('ember-cli/lib/broccoli/broccoli-config-replace');
 var babel = require('broccoli-babel-transpiler');
 var stew = require('broccoli-stew');
 var funnel = require('broccoli-funnel');
+var amdNameResolver = require('amd-name-resolver');
 var preprocessJs  = preprocessors.preprocessJs;
 var preprocessTemplates = preprocessors.preprocessTemplates;
 var preprocessCss = preprocessors.preprocessCss;
@@ -26,10 +27,12 @@ var mv = stew.mv;
 var find = stew.find;
 var rm = stew.rm;
 
-function zipTrees(trees1, trees2) {
+function zipTrees(trees1, trees2, options) {
+  options = options || {};
+
   return trees1.map(function(tree1, i) {
     var tree2 = trees2[i];
-    var tree = mergeTrees([tree1, tree2]);
+    var tree = mergeTrees([tree1, tree2], options);
     tree.name = tree2.name;
     return tree;
   });
@@ -493,7 +496,8 @@ Builder.prototype.transpileTree = function(tree) {
     modules: 'amdStrict',
     exportModuleMetadata: true,
     moduleIds: true,
-    sourceMaps: true
+    sourceMaps: true,
+    resolveModuleSource: amdNameResolver
   });
 };
 
@@ -514,13 +518,7 @@ Builder.prototype.javascript = function() {
 
   var transpiledAppTrees = appTrees.map(function(tree) {
     var name = tree.name;
-    var depGraph = '/dep-graph.json';
     var transpiledTree = this.transpileTree(tree);
-
-    if (name === this.testPath) {
-      transpiledTree = mv(transpiledTree, this.name + depGraph, this.testPath + depGraph);
-    }
-
     transpiledTree.name = name;
 
     return transpiledTree;
@@ -533,7 +531,7 @@ Builder.prototype.javascript = function() {
     return transpiledTree;
   }, this);
 
-  var addonTrees = zipTrees(this.dist(), transpiledAddonTrees);
+  var addonTrees = zipTrees(transpiledAddonTrees, this.dist(), {overwrite: true});
   var trees = transpiledAppTrees.concat(addonTrees);
   return trees;
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "license": "MIT",
   "dependencies": {
     "broccoli-es3-safe-recast": "^2.0.0",
-    "broccoli-babel-transpiler": "git://github.com/chadhietala/broccoli-babel-transpiler#dep-export",
+    "broccoli-babel-transpiler": "^5.2.2",
+    "amd-name-resolver": "git://github.com/chadhietala/amd-name-resolver",
     "broccoli-funnel": "^0.2.3",
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-stew": "^0.2.1",


### PR DESCRIPTION
Prior to this commit the import names were relative and thus we could not resolve the graph.  There was also a bug where the dist directory was getting overriden, when ideally we want to take the dist tree if it is available.
