### PR TITLE
Clean up tree naming

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -27,27 +27,6 @@ var mv = stew.mv;
 var find = stew.find;
 var rm = stew.rm;
 
-function zipTrees(trees1, trees2, options) {
-  options = options || {};
-
-  return trees1.map(function(tree1, i) {
-    var tree2 = trees2[i];
-    var tree = mergeTrees([tree1, tree2], options);
-    tree.name = tree2.name;
-    return tree;
-  });
-}
-
-function mergeTrees(inputTree, options) {
-  var tree = upstreamMergeTrees(inputTree, options);
-  tree.description = options && options.description;
-  return tree;
-}
-
-function flatten(arr) {
-  return [].concat.apply([], arr);
-}
-
 function Builder(options) {
   options = options || {};
 
@@ -293,7 +272,7 @@ Builder.prototype.addonTreesFor = function(type) {
       var tree = addon.treeFor(type);
 
       if (tree && addon.pkg) {
-        tree.name = addon.pkg.name;
+        Builder.nameTree(tree, addon.pkg.name);
       }
 
       return tree;
@@ -517,23 +496,23 @@ Builder.prototype.javascript = function() {
   );
 
   var transpiledAppTrees = appTrees.map(function(tree) {
-    var name = tree.name;
-    var transpiledTree = this.transpileTree(tree);
-    transpiledTree.name = name;
-
-    return transpiledTree;
+    return Builder.nameTree(this.transpileTree(tree), tree.name);
   }, this).concat(packagerFiles);
 
   var transpiledAddonTrees = this.addonJavascript().map(function(tree) {
-    var name = tree.name;
-    var transpiledTree = this.transpileTree(this.setAddonLoadPath(tree, name));
-    transpiledTree.name = name;
-    return transpiledTree;
+    return Builder.nameTree(
+      this.transpileTree(this.setAddonLoadPath(tree, tree.name)), tree.name
+    );
   }, this);
 
   var addonTrees = zipTrees(transpiledAddonTrees, this.dist(), {overwrite: true});
   var trees = transpiledAppTrees.concat(addonTrees);
   return trees;
+};
+
+Builder.nameTree = function(tree, name) {
+  tree.name = name;
+  return tree;
 };
 
 Builder.prototype._configReplacePatterns = function() {
@@ -596,7 +575,7 @@ Builder.prototype.styles = function() {
 Builder.prototype.collectTreeDescriptors = function() {
   var treeDescriptors = {};
   var appName = this.project.pkg.name;
-  var appTest = appName + '/tests';
+  var appTest = this.testPath;
   var appAndTests = [appName, appTest];
 
   this.project.addons.forEach(function(addon) {
@@ -680,6 +659,25 @@ function calculateModulePrefix(config) {
 
 function calculateAppConfig(config) {
   return JSON.stringify(config.APP || {});
+}
+
+function zipTrees(trees1, trees2, options) {
+  options = options || {};
+
+  return trees1.map(function(tree1, i) {
+    var tree2 = trees2[i];
+    return Builder.nameTree(mergeTrees([tree1, tree2], options), tree2.name);
+  });
+}
+
+function mergeTrees(inputTree, options) {
+  var tree = upstreamMergeTrees(inputTree, options);
+  tree.description = options && options.description;
+  return tree;
+}
+
+function flatten(arr) {
+  return [].concat.apply([], arr);
 }
 
 module.exports = Builder;


### PR DESCRIPTION
Prior to this commit we scattered the tree naming through out the function bodies. Also from an outsider's point of view it was not clear what we were doing.  This cleans that up and ensures tree naming goes through `Builder.nameTree`.
