### PR TITLE
Allow Babel options to be passed

### DIFF
--- a/lib/assembler.js
+++ b/lib/assembler.js
@@ -10,7 +10,7 @@ var Project = require('ember-cli/lib/models/project');
 // TODO: this actually need to be passed in
 var preprocessors = require('ember-cli-preprocess-registry/preprocessors');
 var merge = require('lodash-node/modern/object/merge');
-var defaults = require('lodash-node/modern/object/defaults');
+var defaults = require('merge-defaults');
 var fs = require('fs');
 var path = require('path');
 var unwatchedTree = require('broccoli-unwatched-tree');
@@ -553,14 +553,25 @@ Assembler.prototype.vendor = function() {
   });
 };
 
-Assembler.prototype.transpileTree = function(tree) {
-  return new babel(tree, {
+Assembler.prototype._mergeBabelOptions = function () {
+  var defaultBabelOptions = {
     modules: 'amdStrict',
-    exportModuleMetadata: true,
     moduleIds: true,
+    exportModuleMetadata: true,
     sourceMaps: true,
     resolveModuleSource: amdNameResolver
-  });
+  };
+  var babelOptions = this.options.babel || {};
+
+  this.babelOptions = defaults(babelOptions, defaultBabelOptions);
+
+  return this.babelOptions;
+};
+
+Assembler.prototype.transpileTree = function(tree) {
+  var babelOptions = this._mergeBabelOptions();
+
+  return new babel(tree, babelOptions);
 };
 
 Assembler.prototype.javascript = function() {
@@ -688,7 +699,17 @@ Assembler.prototype.collectTreeDescriptors = function() {
   this.treeDescriptors = treeDescriptors;
 };
 
+/**
+ * Evicts addons that are now resident pieces to Ember CLI build pipeline
+ * @return {Nil}
+ */
+Assembler.prototype.evictLegacyAddons = function() {
+  this.registry.remove('javascript', 'ember-cli-babel');
+};
+
 Assembler.prototype.toArray = function() {
+  this.evictLegacyAddons();
+
   var sourceTrees = [
     this.index(),
     this.javascript(),

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "exists-sync": "0.0.3",
     "fs-extra": "^0.20.1",
     "lodash-node": "^3.7.0",
+    "merge-defaults": "^0.2.1",
     "minimatch": "^2.0.8",
     "silent-error": "^1.0.0",
     "walk-sync": "^0.1.3"

--- a/tests/unit/assembler-test.js
+++ b/tests/unit/assembler-test.js
@@ -7,6 +7,7 @@ var Project   = require('ember-cli/lib/models/project');
 var Assembler = require('../../lib/assembler');
 var expect    = require('chai').expect;
 var stub      = require('ember-cli/tests/helpers/stub').stub;
+var amdNameResolver = require('amd-name-resolver');
 
 describe('assembler', function() {
   var project, projectPath, assembler, addonTreesForStub, addon;
@@ -191,6 +192,46 @@ describe('assembler', function() {
     });
   });
 
+  describe('_mergeBabelOptions', function() {
+    it('should return the default options', function() {
+      assembler = new Assembler({
+        project: project
+      });
+
+      assembler._mergeBabelOptions();
+
+      expect(assembler.babelOptions).to.deep.eql({
+        exportModuleMetadata: true,
+        moduleIds: true,
+        modules: 'amdStrict',
+        resolveModuleSource: amdNameResolver,
+        sourceMaps: true
+      });
+    });
+
+    it('should merge user options with defaults', function() {
+      assembler = new Assembler({
+        project: project,
+        babel: {
+          nonStandard: false,
+          whitelist: ['es7.asyncFunctions', 'es7.decorators']
+        }
+      });
+
+      assembler._mergeBabelOptions();
+
+      expect(assembler.babelOptions).to.deep.eql({
+        exportModuleMetadata: true,
+        moduleIds: true,
+        modules: 'amdStrict',
+        nonStandard: false,
+        resolveModuleSource: amdNameResolver,
+        sourceMaps: true,
+        whitelist: ['es7.asyncFunctions', 'es7.decorators']
+      });
+    });
+  });
+
   describe('addons', function() {
     describe('included hook', function() {
       it('included hook is called properly on instantiation', function() {
@@ -339,7 +380,6 @@ describe('assembler', function() {
           expect(assembler.project.addons.length).to.equal(6);
         });
       });
-
     });
   });
 });


### PR DESCRIPTION
This comment allows devs to configure the resident babel transpiler. It
also evicts the Ember CLI Babel plugin as it is no longer needed.
