### PR TITLE
Assembler refactor

### DIFF
--- a/lib/assembler.js
+++ b/lib/assembler.js
@@ -402,12 +402,16 @@ Assembler.prototype.index = function() {
  * @return {Boolean}
  */
 Assembler.prototype._implementsTreeType = function(addon, type) {
-  var typePath = path.join(addon.root, addon.treePaths[type]);
+  if (addon.treePaths && addon.treePaths[type]) {
+    var typePath = path.join(addon.root, addon.treePaths[type]);
 
-  if (existsSync(typePath)) {
-    return walkSync(typePath).filter(function(relativePath) {
-      return relativePath !== '.gitkeep';
-    }).length > 0;
+    if (existsSync(typePath)) {
+      return walkSync(typePath).filter(function(relativePath) {
+        return relativePath !== '.gitkeep';
+      }).length > 0;
+    } else {
+      return false;
+    }
   }
 
   return false;

--- a/lib/assembler.js
+++ b/lib/assembler.js
@@ -5,6 +5,8 @@ var SilentError = require('silent-error');
 var ES3SafeFilter = require('broccoli-es3-safe-recast');
 var upstreamMergeTrees = require('broccoli-merge-trees');
 var cleanBaseURL = require('clean-base-url');
+var TreeDescriptor = require('./models/tree-descriptor');
+var Cache = require('./cache');
 // TODO: this is now passed in
 var Project = require('ember-cli/lib/models/project');
 // TODO: this actually need to be passed in
@@ -23,6 +25,7 @@ var amdNameResolver = require('amd-name-resolver');
 var loadPath = require('./load-path');
 var chalk = require('chalk');
 var existsSync = require('exists-sync');
+var walkSync = require('walk-sync');
 var preprocessJs  = preprocessors.preprocessJs;
 var preprocessTemplates = preprocessors.preprocessTemplates;
 var preprocessCss = preprocessors.preprocessCss;
@@ -50,6 +53,7 @@ function Assembler(options) {
   this.legacyTrees = [];
   this._importTrees = [];
   this.legacyImports = [];
+  this.cache = new Cache();
 
   // @deprecated
   this.bowerDirectory = this.project.bowerDirectory;
@@ -88,6 +92,10 @@ Assembler.prototype.import = function(asset, options) {
   }
 };
 
+Assembler.prototype.dependencies = function(pkg) {
+  return this.project.dependencies(pkg);
+};
+
 /**
   @private
   @method _importAssetTree
@@ -96,12 +104,18 @@ Assembler.prototype.import = function(asset, options) {
  */
 Assembler.prototype._importAssetTree = function(directory, subdirectory) {
   if (existsSync(directory) && this._importTrees.indexOf(directory) === -1) {
-    var assetTree = new funnel(directory, {
+    var tree = new funnel(directory, {
       srcDir: '/',
       destDir: subdirectory
     });
 
-    this._importTrees.push(assetTree);
+    var legacyDesc = new TreeDescriptor({
+      name: directory,
+      treeType: 'legacy',
+      tree: tree
+    });
+
+    this.cache.set(directory, legacyDesc);
   }
 };
 
@@ -306,17 +320,25 @@ Assembler.prototype._contentForAppBoot = function(content, config) {
   content.push('}');
 };
 
-Assembler.prototype.dependencies = function(pkg) {
-  return this.project.dependencies(pkg);
-};
-
 Assembler.prototype.testIndex = function() {
-  return mv(configReplace(this.trees.tests, this._configTree(), {
+  var tree = mv(configReplace(this.trees.tests, this._configTree(), {
     configPath: path.join(this.name, 'config', 'environments', 'test.json'),
     files: [ 'index.html' ],
     env: 'test',
     patterns: this._configReplacePatterns()
   }), this.testPath);
+
+  var testDesc = new TreeDescriptor({
+    name: this.testPath,
+    tree: tree,
+    treeType: 'index',
+    root: this.project.root,
+    nodeModulesPath: this.project.nodeModulesPath,
+    pkg: this.project.pkg,
+    packageName: this.project.pkg.name
+  });
+
+  this.cache.set(this.testPath, testDesc);
 };
 
 Assembler.prototype.testFiles = function() {
@@ -324,7 +346,7 @@ Assembler.prototype.testFiles = function() {
   // var testSupportPath = this.options.outputPaths.testSupport.js;
   // testSupportPath = testSupportPath.testSupport || testSupportPath;
 
-  var testem = funnel(testemTree, {
+  var tree = funnel(testemTree, {
     files: ['testem.js'],
     destDir: this.testPath
   });
@@ -335,10 +357,17 @@ Assembler.prototype.testFiles = function() {
     this.options.fingerprint.exclude.push('testem');
   }
 
-  return [
-    testem
-    // testSupport
-  ];
+  var testSupportDesc = new TreeDescriptor({
+    name: this.testPath,
+    treeType: 'tests',
+    tree: tree,
+    root: this.project.root,
+    nodeModulesPath: this.project.nodeModulesPath,
+    pkg: this.project.pkg,
+    packageName: this.project.pkg.name
+  });
+
+  this.cache.set(this.testPath, testSupportDesc);
 };
 
 Assembler.prototype.index = function() {
@@ -347,25 +376,76 @@ Assembler.prototype.index = function() {
     return relativePath === 'index.html' ? htmlName : relativePath;
   });
 
-  var self = this;
-
-  return mv(configReplace(index, this._configTree(), {
+  var tree = mv(configReplace(index, this._configTree(), {
     configPath: path.join(this.name, 'config', 'environments', this.env + '.json'),
     files: [ htmlName ],
     patterns: this._configReplacePatterns()
-  }), self.name + '/');
+  }), this.name + '/');
+
+  var descriptor = new TreeDescriptor({
+    name: this.name,
+    treeType: 'index',
+    tree: tree,
+    root: this.project.root,
+    nodeModulesPath: this.project.nodeModulesPath,
+    pkg: this.project.pkg,
+    packageName: this.project.pkg.name
+  });
+
+  this.cache.set(this.name, descriptor);
+};
+
+/**
+ * Checks to see if the addon actually contains files
+ * @param  {Object} addon An addon model
+ * @param  {String} type  The type of tree we are verifing
+ * @return {Boolean}
+ */
+Assembler.prototype._implementsTreeType = function(addon, type) {
+  var typePath = path.join(addon.root, addon.treePaths[type]);
+
+  if (existsSync(typePath)) {
+    return walkSync(typePath).filter(function(relativePath) {
+      return relativePath !== '.gitkeep';
+    }).length > 0;
+  }
+
+  return false;
+};
+
+Assembler.prototype._fileTypesInTree = function(addon, type) {
+  var typePath = path.join(addon.root, addon.treePaths[type]);
+  if (existsSync(typePath)) {
+    return uniq(walkSync(typePath).filter(byFile).map(byExtension));
+  }
+
+  return [];
+};
+
+Assembler.prototype.createAddonDescriptor = function(addon, type) {
+  if (addon.treeFor) {
+    if (this._implementsTreeType(addon, type)) {
+      var tree = addon.treeFor(type);
+      var descriptor = new TreeDescriptor({
+        name: addon.name,
+        tree: tree,
+        treeType: type,
+        packageName: addon.pkg.name,
+        pkg: addon.pkg,
+        nodeModulesPath: addon.nodeModulesPath,
+        root: addon.root
+      });
+
+      this.cache.set(addon.name, descriptor);
+    }
+  }
 };
 
 Assembler.prototype.addonTreesFor = function(type) {
   return this.project.addons.map(function(addon) {
     if (addon.treeFor) {
-      var tree = addon.treeFor(type);
-
-      if (tree && addon.pkg) {
-        Assembler.nameTree(tree, addon.pkg.name);
-      }
-
-      return tree;
+      this.createAddonDescriptor(addon, type);
+      return addon.treeFor(type);
     }
   }, this).filter(Boolean);
 };
@@ -381,22 +461,35 @@ Assembler.prototype._filterAppTree = function() {
     return this._cachedFilterAppTree;
   }
 
+  return this._cachedFilterAppTree = find(this.trees.app, {
+    exclude: this._filterStylesAndTemplates()
+  });
+};
+
+Assembler.prototype._filterStylesAndTemplates = function() {
   var podPatterns = this._podTemplatePatterns();
-  var excludePatterns = podPatterns.concat([
+  return podPatterns.concat([
     // note: do not use path.sep here Funnel uses
     // walk-sync which always joins with `/` (not path.sep)
     new RegExp('^styles/'),
     new RegExp('^templates/'),
   ]);
+};
 
-  return this._cachedFilterAppTree = find(this.trees.app, {
-    exclude: excludePatterns
+Assembler.prototype._filteredAddonAppDir = function() {
+  return this.cache.descriptorsByType('app').map(function(descriptor) {
+    descriptor.trees.app = find(descriptor.trees.app, {
+      exclude: this._filterStylesAndTemplates()
+    });
+    this.cache.set(descriptor.name, descriptor);
+
+    return descriptor.trees.app;
   });
 };
 
 // Merges an addons app directory with the consuming app
 Assembler.prototype._processedAppTree = function() {
-  var filteredAddons = this.addonTreesFor('app').concat(this._filterAppTree());
+  var filteredAddons = this._filteredAddonAppDir().concat(this._filterAppTree());
   return mv(mergeTrees(filteredAddons, {
     overwrite: true,
     description: 'TreeMerger (app)'
@@ -405,7 +498,7 @@ Assembler.prototype._processedAppTree = function() {
 
 Assembler.prototype._processedTemplatesTree = function() {
   var addonTrees = this.addonTreesFor('templates');
-  var addonPodTemplates = find(this.addonTreesFor('app'), 'pods/**/template.*');
+  var addonPodTemplates = find(this.cache.treesByType('app'), 'pods/**/template.*');
   var mergedTrees = this.trees.templates ? addonTrees.concat(this.trees.templates) : addonTrees;
   var mergedTemplates = mergeTrees(mergedTrees, {
     overwrite: true,
@@ -454,7 +547,7 @@ Assembler.prototype.appJavascript = function() {
   var app = this._processedAppTree();
   var templates = this._processedTemplatesTree();
 
-  if (!this.registry.availablePlugins['ember-cli-babel'] && this.options.es3Safe) {
+  if (this.options.es3Safe) {
     app = new ES3SafeFilter(app);
   }
 
@@ -464,11 +557,17 @@ Assembler.prototype.appJavascript = function() {
 
   var postprocessedApp = this.addonPostprocessTree('js', preprocessedApp);
 
-  return mergeTrees([postprocessedApp, templates]);
-};
+  var appTreeDescriptor = new TreeDescriptor({
+    name: this.name,
+    packageName: this.name,
+    nodeModulesPath: this.project.nodeModulesPath,
+    root: this.project.root,
+    treeType: 'app',
+    tree: mergeTrees([postprocessedApp, templates]),
+    pkg: this.project.pkg
+  });
 
-Assembler.prototype.addonJavascript = function() {
-  return this.addonTreesFor('addon');
+  this.cache.set(this.name, appTreeDescriptor);
 };
 
 Assembler.prototype._processedTestsTree = function() {
@@ -479,8 +578,6 @@ Assembler.prototype._processedTestsTree = function() {
 };
 
 Assembler.prototype.appTests = function() {
-  var testTrees = [];
-
   if (this.tests) {
     var tests = this._processedTestsTree();
 
@@ -488,12 +585,18 @@ Assembler.prototype.appTests = function() {
       registry: this.registry
     });
 
-    preprocessedTests.name = this.testPath;
+    var testTreeDescriptor = new TreeDescriptor({
+      name: this.testPath,
+      packageName: this.name,
+      nodeModulesPath: this.project.nodeModulesPath,
+      tree: preprocessedTests,
+      root: this.project.root,
+      treeType: 'tests',
+      pkg: this.project.pkg
+    });
 
-    testTrees.push(preprocessedTests);
+    this.cache.set(this.testPath, testTreeDescriptor);
   }
-
-  return testTrees;
 };
 
 Assembler.prototype.packagerFiles = function() {
@@ -502,6 +605,7 @@ Assembler.prototype.packagerFiles = function() {
   }
 
   var envFilePath = this.name + '/config/environment.js';
+  var packager = '__packager__';
 
   // TODO we need the loader in here
   var files = [
@@ -526,31 +630,48 @@ Assembler.prototype.packagerFiles = function() {
   packagerFiles = funnel(packagerFiles, {
     files: files,
     srcDir: '/',
-    destDir: '/__packager__'
+    destDir: '/' + packager
   });
 
-  var envFile = rename(find(packagerFiles, { include: ['__packager__/environment.js'] }), function() {
+  var envFile = rename(find(packagerFiles, { include: [packager + '/environment.js'] }), function() {
     return envFilePath;
   });
 
-  packagerFiles = rm(packagerFiles, '__packager__/environment.js');
+  packagerFiles = rm(packagerFiles, packager + '/environment.js');
 
-  return {
-    packagerFiles: packagerFiles,
-    envFile: envFile
-  };
-};
+  var envTreeDescriptor = new TreeDescriptor({
+    name: envFilePath,
+    tree: envFile,
+    treeType: 'environment',
+    root: this.project.root,
+    nodeModulesPath: this.project.nodeModulesPath,
+    pkg: this.project.pkg,
+    packageName: this.name
+  });
 
-Assembler.prototype.dist = function() {
-  return this.addonTreesFor('dist');
+  var packageDescriptor = new TreeDescriptor({
+    name: packager,
+    treeType: 'packager',
+    tree: packagerFiles,
+    root: null,
+    nodeModulesPath: null,
+    pkg: null,
+    packageName: packager
+  });
+
+  this.cache.set(packager, packageDescriptor);
+  this.cache.set('environment', envTreeDescriptor);
 };
 
 Assembler.prototype.vendor = function() {
-  return this.addonTreesFor('vendor').map(function(tree) {
-    return rename(tree, function(relativePath) {
+  this.addonTreesFor('vendor');
+
+  this.cache.descriptorsByType('vendor').forEach(function(descriptor) {
+    descriptor.trees.app = rename(descriptor.trees.app, function(relativePath) {
       return 'vendor/' + relativePath;
     });
-  });
+    this.cache.set(descriptor.name, descriptor);
+  }, this);
 };
 
 Assembler.prototype._mergeBabelOptions = function () {
@@ -574,35 +695,40 @@ Assembler.prototype.transpileTree = function(tree) {
   return new babel(tree, babelOptions);
 };
 
+Assembler.prototype.populateCacheForJavascript = function() {
+  this.packagerFiles();
+  this.appJavascript();
+  this.appTests();
+  this.vendor();
+  this.addonTreesFor('addon');
+  this.addonTreesFor('dist');
+};
+
 Assembler.prototype.javascript = function() {
-  var appTrees = [];
-  var packagerFiles = this.packagerFiles();
-  var appJavascript = mergeTrees([this.appJavascript(), packagerFiles.envFile]);
-  var appTests;
+  this.populateCacheForJavascript();
 
-  appJavascript.name = this.name;
-  packagerFiles.name = '__packager__';
-  appTests = this.appTests();
+  var cache = this.cache;
+  var envFile = cache.get('environment');
+  var appJavascript = cache.get(this.name);
+  var appTests = cache.get(this.testPath);
 
-  appTrees = appTrees.concat(
-    appJavascript,
-    appTests
+  appJavascript.trees.app = this.transpileTree(
+    mergeTrees([appJavascript.trees.app, envFile.trees.environment])
   );
 
-  var transpiledAppTrees = appTrees.map(function(tree) {
-    return Assembler.nameTree(this.transpileTree(tree), tree.name);
-  }, this).concat(packagerFiles.packagerFiles);
+  cache.set(this.name, appJavascript);
+  cache.remove('environment');
 
-  var transpiledAddonTrees = this.addonJavascript().map(function(tree) {
-    return Assembler.nameTree(
-      this.transpileTree(loadPath(tree, {
-        name: tree.name
-      })), tree.name
-    );
+  if (appTests) {
+    appTests.tree = this.transpileTree(appTests.tree);
+    cache.set(this.testPath, appTests);
+  }
+
+  cache.descriptorsByType('addon').forEach(function(descriptor) {
+    descriptor.trees.addon = this.transpileTree(loadPath(descriptor.trees.addon, { name: descriptor.name }));
+    cache.set(descriptor.name, descriptor);
   }, this);
 
-  var addonTrees = zipTrees(transpiledAddonTrees, this.dist(), {overwrite: true});
-  return transpiledAppTrees.concat(addonTrees, this.vendor());
 };
 
 Assembler.prototype._configReplacePatterns = function() {
@@ -619,16 +745,23 @@ Assembler.prototype._configReplacePatterns = function() {
 };
 
 Assembler.prototype.publicTree = function() {
-  var trees = this.addonTreesFor('public');
-
-  if (this.trees.public) {
-    trees.push(this.trees.public);
-  }
-
-  return mv(mergeTrees(trees, {
+  var trees = this.addonTreesFor('public').concat(this.trees.public ? this.trees.public : []);
+  var tree = mv(mergeTrees(trees, {
     overwrite: true,
     description: 'TreeMerger (public)'
   }), this.name + '/');
+
+  var publicDesc = new TreeDescriptor({
+    name: this.name,
+    treeType: 'public',
+    tree: tree,
+    root: this.project.root,
+    nodeModulesPath: this.project.nodeModulesPath,
+    pkg: this.project.pkg,
+    packageName: this.project.pkg.name
+  });
+
+  this.cache.set(this.name, publicDesc);
 };
 
 Assembler.prototype.styles = function() {
@@ -651,7 +784,7 @@ Assembler.prototype.styles = function() {
 
   options.registry = this.registry;
 
-  var preprocessedStyles = preprocessCss(styles, '/', this.name + '/', options);
+  var preprocessedStyles = mv(preprocessCss(styles, '/app/styles', this.name, options), this.name + '/styles');
 
   if (this.options.minifyCSS.enabled === true) {
     options = this.options.minifyCSS.options || {};
@@ -659,44 +792,17 @@ Assembler.prototype.styles = function() {
     preprocessedStyles = preprocessMinifyCss(preprocessedStyles, options);
   }
 
-  return mv(this.addonPostprocessTree('css', preprocessedStyles), this.name + '/styles');
-};
-
-Assembler.prototype.collectTreeDescriptors = function() {
-  var treeDescriptors = {};
-  var appName = this.project.pkg.name;
-  var appTest = this.testPath;
-  var appAndTests = [appName, appTest];
-
-  this.project.addons.forEach(function(addon) {
-    treeDescriptors[addon.pkg.name] = {
-      packageName: addon.pkg.name,
-      root: addon.root,
-      pkg: addon.pkg,
-      nodeModulesPath: addon.nodeModulesPath
-    };
-    if (addon.parent) {
-      treeDescriptors[addon.pkg.name].parent = {
-        packageName: addon.parent.name(),
-        pkg: addon.parent.pkg,
-        root: addon.parent.root,
-        nodeModulesPath: addon.parent.nodeModulesPath
-      };
-    }
+  var styleDesc = new TreeDescriptor({
+    name: this.name,
+    treeType: 'styles',
+    tree: preprocessedStyles,
+    root: this.project.root,
+    nodeModulesPath: this.project.nodeModulesPath,
+    pkg: this.project.pkg,
+    packageName: this.project.pkg.name
   });
 
-  appAndTests.forEach(function(name) {
-    treeDescriptors[name] = {
-      packageName: name,
-      pkg: this.project.pkg,
-      root: this.project.root,
-      nodeModulesPath: this.project.nodeModulesPath
-    };
-  }, this);
-
-  treeDescriptors['__packager__'] = {};
-
-  this.treeDescriptors = treeDescriptors;
+  this.cache.set(this.name, styleDesc);
 };
 
 /**
@@ -707,33 +813,15 @@ Assembler.prototype.evictLegacyAddons = function() {
   this.registry.remove('javascript', 'ember-cli-babel');
 };
 
-Assembler.prototype.toArray = function() {
+Assembler.prototype.assemble = function() {
   this.evictLegacyAddons();
-
-  var sourceTrees = [
-    this.index(),
-    this.javascript(),
-    this.publicTree(),
-    this.styles()
-  ];
-
-  if (this.tests) {
-    sourceTrees = sourceTrees.concat(this.testIndex(), this.testFiles());
-  }
-
-  this.collectTreeDescriptors();
-
-  return sourceTrees;
-};
-
-Assembler.prototype.toTree = function(additionalTrees) {
-  additionalTrees = additionalTrees || [];
-  return flatten(this.toArray()).concat(additionalTrees, this._importTrees);
-};
-
-Assembler.nameTree = function(tree, name) {
-  tree.name = name;
-  return tree;
+  this.index();
+  this.javascript();
+  this.publicTree();
+  this.styles();
+  this.testIndex();
+  this.testFiles();
+  return this.cache;
 };
 
 Assembler.env = function() {
@@ -767,14 +855,6 @@ function calculateAppConfig(config) {
   return JSON.stringify(config.APP || {});
 }
 
-function zipTrees(trees1, trees2, options) {
-  options = options || {};
-
-  return trees1.map(function(tree1, i) {
-    var tree2 = trees2[i];
-    return Assembler.nameTree(mergeTrees([tree1, tree2], options), tree2.name);
-  });
-}
 
 function mergeTrees(inputTree, options) {
   var tree = upstreamMergeTrees(inputTree, options);
@@ -782,8 +862,19 @@ function mergeTrees(inputTree, options) {
   return tree;
 }
 
-function flatten(arr) {
-  return [].concat.apply([], arr);
+
+function byFile(relativePath) {
+  return relativePath.splice(-1) !== '/';
+}
+
+function byExtension(relativePath) {
+  return path.extname(relativePath);
+}
+
+function uniq(array) {
+  return array.filter(function(item, i, self) {
+    return self.indexOf(item) === i;
+  });
 }
 
 module.exports = Assembler;

--- a/lib/assembler.js
+++ b/lib/assembler.js
@@ -477,6 +477,7 @@ Assembler.prototype._filterStylesAndTemplates = function() {
 };
 
 Assembler.prototype._filteredAddonAppDir = function() {
+  this.addonTreesFor('app');
   return this.cache.descriptorsByType('app').map(function(descriptor) {
     descriptor.trees.app = find(descriptor.trees.app, {
       exclude: this._filterStylesAndTemplates()
@@ -484,7 +485,7 @@ Assembler.prototype._filteredAddonAppDir = function() {
     this.cache.set(descriptor.name, descriptor);
 
     return descriptor.trees.app;
-  });
+  }, this);
 };
 
 // Merges an addons app directory with the consuming app

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,53 @@
+'use strict';
+
+function DescriptorCache() {
+  this.store = Object.create(null);
+}
+
+DescriptorCache.prototype.get = function(key) {
+  return this.store[key];
+};
+
+DescriptorCache.prototype.all = function() {
+  return this.store;
+};
+
+DescriptorCache.prototype.set = function(key, value) {
+  if (!this._contains(key)) {
+    this.store[key] = value;
+  } else {
+    this.store[key].update(value);
+  }
+};
+
+DescriptorCache.prototype._treeByType = function(key, treeType) {
+  if (this.store[key]) {
+    return this.store[key].trees[treeType];
+  }
+
+  throw new Error(key + ' was not found in the descriptor cache.');
+};
+
+DescriptorCache.prototype.treesByType = function(treeType) {
+  return Object.keys(this.store).map(function(key) {
+    return this._treeByType(key, treeType);
+  }, this).filter(Boolean);
+};
+
+DescriptorCache.prototype.descriptorsByType = function(treeType) {
+  return Object.keys(this.store).filter(function(key) {
+    return Object.keys(this.store[key].trees).indexOf(treeType) > -1;
+  }, this).map(function(key) {
+    return this.store[key];
+  }, this);
+};
+
+DescriptorCache.prototype._contains = function(key) {
+  return !!this.store[key];
+};
+
+DescriptorCache.prototype.remove = function(key) {
+  delete this.store[key];
+};
+
+module.exports = DescriptorCache;

--- a/lib/models/tree-descriptor.js
+++ b/lib/models/tree-descriptor.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var mergeTrees = require('broccoli-merge-trees');
+
+function TreeDescriptor(options) {
+  this.trees = {};
+  this.trees[options.treeType] = options.tree;
+  this._treeTypes = [options.treeType];
+  this.packageName = options.packageName;
+  this.name = options.name;
+  this.srcDir = options.srcDir;
+  this.root = options.root;
+  this.pkg = options.pkg;
+  this.nodeModulesPath = options.nodeModulesPath;
+}
+
+TreeDescriptor.prototype.update = function(newDescriptor) {
+  var treeType = newDescriptor._treeTypes[0];
+  this._treeTypes = this._treeTypes.concat(newDescriptor._treeTypes);
+  if (!this.trees[treeType]) {
+    this.trees[treeType] = newDescriptor.trees[treeType];
+  } else {
+    this.trees[treeType] = mergeTrees([
+      this.trees[treeType],
+      newDescriptor.trees[treeType]
+    ], { overwrite: true });
+  }
+};
+
+module.exports = TreeDescriptor;

--- a/tests/acceptance/assembler-acceptance-test.js
+++ b/tests/acceptance/assembler-acceptance-test.js
@@ -53,13 +53,12 @@ describe('Acceptance: Assembler', function() {
     expect(cache instanceof Cache).to.eql(true);
   });
 
-  it.only('addons should not override the consuming applications files if the same file exists', function () {
+  it('addons should not override the consuming applications files if the same file exists', function () {
     assembler = new Assembler();
     var cache = assembler.assemble();
-    var trees = cache.treesByType('app');
-    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
+    var tree = cache.get('dummy').trees.app;
+    build = new broccoli.Builder(tree);
     return build.build().then(function(results) {
-      console.log(walkSync(results.directory))
       var basePath = path.join(results.directory, 'dummy/components');
       var containsAddon = fs.readFileSync(path.join(basePath, 'foo-bar.js'), 'utf8').indexOf('fromAddon') > -1;
       expect(!containsAddon).to.eql(true);

--- a/tests/acceptance/assembler-acceptance-test.js
+++ b/tests/acceptance/assembler-acceptance-test.js
@@ -7,6 +7,7 @@ var expect = require('chai').expect;
 var mergeTrees = require('broccoli-merge-trees');
 var fs = require('fs');
 var walkSync = require('walk-sync');
+var Cache = require('../../lib/cache');
 
 function verifyFiles(files, expected) {
   expected.forEach(function(file) {
@@ -46,17 +47,19 @@ describe('Acceptance: Assembler', function() {
     expect(assembler.options).to.be.an('object');
   });
 
-  it('should create an array of trees', function() {
+  it('should create cache of tree descriptors', function() {
     assembler = new Assembler();
-    var trees = assembler.toTree();
-    expect(trees).to.be.an('array');
+    var cache = assembler.assemble();
+    expect(cache instanceof Cache).to.eql(true);
   });
 
-  it('addons should not override the consuming applications files if the same file exists', function () {
+  it.only('addons should not override the consuming applications files if the same file exists', function () {
     assembler = new Assembler();
-    var trees = assembler.toTree();
+    var cache = assembler.assemble();
+    var trees = cache.treesByType('app');
     build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
+      console.log(walkSync(results.directory))
       var basePath = path.join(results.directory, 'dummy/components');
       var containsAddon = fs.readFileSync(path.join(basePath, 'foo-bar.js'), 'utf8').indexOf('fromAddon') > -1;
       expect(!containsAddon).to.eql(true);
@@ -65,20 +68,25 @@ describe('Acceptance: Assembler', function() {
     });
   });
 
-  it('should have the index.html', function() {
+  it('should have the app and test index.html', function() {
     assembler = new Assembler();
-    var trees = assembler.toTree();
+    var cache = assembler.assemble();
+    var trees = cache.treesByType('index');
+
     build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var files = walkSync(results.directory);
       expect(files.indexOf('dummy/index.html') > -1).to.be.eql(true);
+      expect(files.indexOf('dummy/tests/index.html') > -1).to.be.eql(true);
     });
   });
 
   it('should contain a dep-graph.json per tree', function() {
     assembler = new Assembler();
-    var trees = assembler.toTree();
-    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
+    var cache = assembler.assemble();
+    var tree = cache.get('dummy').trees.app;
+
+    build = new broccoli.Builder(tree);
     return build.build().then(function(results) {
       var files = walkSync(results.directory);
       expect(files.indexOf('dep-graph.json') > -1).to.be.eql(true);
@@ -87,7 +95,9 @@ describe('Acceptance: Assembler', function() {
 
   it('should allow for both addon structures', function() {
     assembler = new Assembler();
-    var trees = assembler.toTree();
+    var cache = assembler.assemble();
+    var trees = cache.treesByType('addon');
+
     build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var files = walkSync(results.directory).filter(function(relativePath) {
@@ -136,32 +146,10 @@ describe('Acceptance: Assembler', function() {
     });
   });
 
-  it('should include ember from the addon directory', function () {
-    assembler = new Assembler();
-    var trees = assembler.toTree();
-    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
-    return build.build().then(function(results) {
-      var files = walkSync(results.directory);
-      var folders = files.filter(function(item) {
-        return item.slice(-1) === '/' && item.split('/').length === 2;
-      });
-
-      expect(files.indexOf('ember.js') > 0).to.eql(true);
-      expect(folders).to.deep.eql([
-        '@scoped/',
-        '__packager__/',
-        'dummy/',
-        'ember/',
-        'ember-cli-current-addon/',
-        'legacy-without-reexport/',
-        'no-reexport-new-structure/'
-      ]);
-    });
-  });
-
   it('should preprocess templates with an installed pre-processor', function () {
     assembler = new Assembler();
-    var trees = assembler.toTree();
+    var cache = assembler.assemble();
+    var trees = cache.treesByType('app');
     build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var expected = fs.readFileSync(path.resolve('..', '..', 'expectations/templates/application.js'), 'utf8');
@@ -170,20 +158,24 @@ describe('Acceptance: Assembler', function() {
     });
   });
 
-  it('should contain tests if environment is development', function () {
+  it('should contain tests and test support', function () {
     assembler = new Assembler();
-    var trees = assembler.toTree();
+    var cache = assembler.assemble();
+    var trees = cache.treesByType('tests');
     build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var files = walkSync(results.directory);
 
       var expectactions = [
+        'dummy/',
         'dummy/tests/',
-        'dummy/tests/index.html',
         'dummy/tests/testem.js',
+        'dummy/tests/index.html',
+        'dummy/tests/test-support/',
+        'dummy/tests/test-support/some-test-thing.js',
         'dummy/tests/unit/',
         'dummy/tests/unit/components/',
-        'dummy/tests/unit/components/foo-bar-test.js',
+        'dummy/tests/unit/components/foo-bar-test.js'
       ];
 
       expect(assembler.env).to.eql('development');
@@ -193,19 +185,10 @@ describe('Acceptance: Assembler', function() {
     });
   });
 
-  it('should contain the test index', function() {
-    assembler = new Assembler();
-    var trees = assembler.toTree();
-    build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
-    return build.build().then(function(results) {
-      var files = walkSync(results.directory);
-      expect(files.indexOf('dummy/tests/index.html') > -1).to.eql(true);
-    });
-  });
-
   it('should not contain tests from the addon', function () {
     assembler = new Assembler();
-    var trees = assembler.toTree();
+    var cache = assembler.assemble();
+    var trees = cache.treesByType('addon');
     build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var files = walkSync(results.directory);
@@ -222,9 +205,10 @@ describe('Acceptance: Assembler', function() {
     });
   });
 
-  it('should include styles', function() {
+  it('should collect styles', function() {
     assembler = new Assembler();
-    var trees = assembler.toTree();
+    var cache = assembler.assemble();
+    var trees = cache.treesByType('styles');
     build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var files = walkSync(results.directory);
@@ -234,7 +218,8 @@ describe('Acceptance: Assembler', function() {
 
   it('styles should have gone through the preprocessor', function() {
     assembler = new Assembler();
-    var trees = assembler.toTree();
+    var cache = assembler.assemble();
+    var trees = cache.treesByType('styles');
     build = new broccoli.Builder(mergeTrees(trees, { overwrite: true }));
     return build.build().then(function(results) {
       var expected = fs.readFileSync(path.resolve('..', '..', 'expectations/styles/foo.css'), 'utf8');

--- a/tests/fixtures/dummy/node_modules/ember-cli-hypebars/index.js
+++ b/tests/fixtures/dummy/node_modules/ember-cli-hypebars/index.js
@@ -25,8 +25,8 @@ module.exports = {
     registry.add('template', {
       name: 'ember-cli-htmlbars',
       ext: 'hbs',
-      toTree: function(tree) {
-        return HypeBars(tree);
+      toTree: function(tree, options) {
+        return HypeBars(tree, options);
       }
     });
   }

--- a/tests/unit/assembler-test.js
+++ b/tests/unit/assembler-test.js
@@ -298,7 +298,7 @@ describe('assembler', function() {
 
         var sampleAddon = project.addons[0];
         var actualTreeName;
-
+//
         sampleAddon.treeFor = function(name) {
           actualTreeName = name;
 
@@ -340,8 +340,7 @@ describe('assembler', function() {
           assembler.styles();
 
           expect(addonTreesForStub.calledWith[0][0]).to.equal('styles');
-          //expect(true, trees.inputTrees[0].inputTree.inputTrees.indexOf('batman') !== -1, 'contains addon tree');
-          //expect(trees.inputTrees[0].inputTree.options.overwrite).to.equal(true);
+          expect(assembler.cache.treesByType('styles')[0].inputTree.inputTree.inputTrees[0]).to.eql('batman');
         });
       });
     });

--- a/tests/unit/cache-test.js
+++ b/tests/unit/cache-test.js
@@ -1,0 +1,183 @@
+'use strict';
+
+var Cache = require('../../lib/cache');
+var TreeDescriptor = require('../../lib/models/tree-descriptor');
+var expect = require('chai').expect;
+
+describe('descriptor cache', function() {
+  var cache;
+  beforeEach(function() {
+    cache = new Cache();
+  });
+
+  afterEach(function() {
+    cache = null;
+  });
+
+  it('should set descriptors into the cache', function() {
+    var desc = new TreeDescriptor({
+      tree: { inputTree: {} },
+      name: 'foo',
+      packageName: 'fizz',
+      treeType: 'app',
+      root: '/',
+      nodeModulesPath: '/node_modules',
+      pkg: {name: 'fizz', version: '1.0.0'}
+    });
+
+    cache.set('foo', desc);
+
+    expect(cache.store.foo).to.be.an('object');
+
+    expect(cache.store.foo.trees).to.deep.eql({
+      app: { inputTree: {} }
+    });
+    expect(cache.store.foo._treeTypes).to.deep.eql(['app']);
+  });
+
+  it('should only update trees if the key already exists', function() {
+    var desc1 = new TreeDescriptor({
+      tree: { inputTree: {} },
+      name: 'foo',
+      packageName: 'fizz',
+      treeType: 'app',
+      root: '/',
+      nodeModulesPath: '/node_modules',
+      pkg: {name: 'fizz', version: '1.0.0'}
+    });
+
+    var desc2 = new TreeDescriptor({
+      tree: { inputTree: {} },
+      name: 'foo',
+      packageName: 'fizz',
+      treeType: 'addon',
+      root: '/',
+      nodeModulesPath: '/node_modules',
+      pkg: {name: 'fizz', version: '1.0.0'}
+    });
+
+    cache.set('foo', desc1);
+    cache.set('foo', desc2);
+
+    expect(cache.store.foo.trees).to.deep.eql({
+      addon: { inputTree: {} },
+      app: { inputTree: {} }
+    });
+  });
+
+  it('should retrieve a descriptor by name', function() {
+    var desc = new TreeDescriptor({
+      tree: { inputTree: {} },
+      name: 'foo',
+      packageName: 'fizz',
+      treeType: 'app',
+      root: '/',
+      nodeModulesPath: '/node_modules',
+      pkg: {name: 'fizz', version: '1.0.0'}
+    });
+
+    cache.set('foo', desc);
+
+    expect(cache.get('foo').name).to.eql('foo');
+  });
+
+  it('should retrieve a descriptor by name', function() {
+    var desc1 = new TreeDescriptor({
+      tree: { inputTree: {} },
+      name: 'foo',
+      packageName: 'fizz',
+      treeType: 'app',
+      root: '/',
+      nodeModulesPath: '/node_modules',
+      pkg: {name: 'fizz', version: '1.0.0'}
+    });
+
+    var desc2 = new TreeDescriptor({
+      tree: { inputTree: {} },
+      name: 'bar',
+      packageName: 'bizz',
+      treeType: 'app',
+      root: '/',
+      nodeModulesPath: '/node_modules',
+      pkg: {name: 'bizz', version: '1.0.0'}
+    });
+
+    cache.set('foo', desc1);
+    cache.set('bar', desc2);
+
+    expect(Object.keys(cache.all())).to.eql(['foo', 'bar']);
+  });
+
+  it('should retrieve trees by a specific type', function() {
+    var desc1 = new TreeDescriptor({
+      tree: { inputTree: {} },
+      name: 'foo',
+      packageName: 'fizz',
+      treeType: 'app',
+      root: '/',
+      nodeModulesPath: '/node_modules',
+      pkg: {name: 'fizz', version: '1.0.0'}
+    });
+
+    var desc2 = new TreeDescriptor({
+      tree: { inputTree: {}, __name: 'bar' },
+      name: 'bar',
+      packageName: 'bizz',
+      treeType: 'addon',
+      root: '/',
+      nodeModulesPath: '/node_modules',
+      pkg: {name: 'bizz', version: '1.0.0'}
+    });
+
+    cache.set('foo', desc1);
+    cache.set('bar', desc2);
+
+    expect(cache.treesByType('addon').length).to.eql(1);
+    expect(cache.treesByType('addon')[0].__name).to.eql('bar');
+  });
+
+  it('should retrieve descriptors by a specific type', function() {
+    var desc1 = new TreeDescriptor({
+      tree: { inputTree: {} },
+      name: 'foo',
+      packageName: 'fizz',
+      treeType: 'app',
+      root: '/',
+      nodeModulesPath: '/node_modules',
+      pkg: {name: 'fizz', version: '1.0.0'}
+    });
+
+    var desc2 = new TreeDescriptor({
+      tree: { inputTree: {}, __name: 'bar' },
+      name: 'bar',
+      packageName: 'bizz',
+      treeType: 'addon',
+      root: '/',
+      nodeModulesPath: '/node_modules',
+      pkg: {name: 'bizz', version: '1.0.0'}
+    });
+
+    cache.set('foo', desc1);
+    cache.set('bar', desc2);
+
+    expect(cache.descriptorsByType('addon').length).to.eql(1);
+    expect(cache.descriptorsByType('addon')[0].name).to.eql('bar');
+  });
+
+  it('should remove descriptor', function() {
+    var desc1 = new TreeDescriptor({
+      tree: { inputTree: {} },
+      name: 'foo',
+      packageName: 'fizz',
+      treeType: 'app',
+      root: '/',
+      nodeModulesPath: '/node_modules',
+      pkg: {name: 'fizz', version: '1.0.0'}
+    });
+
+    cache.set('foo', desc1);
+    cache.remove('foo');
+
+    expect(Object.keys(cache.store).length).to.eql(0);
+  });
+});

--- a/tests/unit/tree-descriptor-test.js
+++ b/tests/unit/tree-descriptor-test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var TreeDescriptor = require('../../lib/models/tree-descriptor');
+var expect = require('chai').expect;
+var path = require('path');
+
+describe('tree descriptor model', function() {
+  var treeDescriptor;
+
+  beforeEach(function() {
+    treeDescriptor = new TreeDescriptor({
+      tree: 'foo',
+      treeType: 'app',
+      packageName: 'foo',
+      name: 'fizzpoo',
+      srcDir: '/',
+      pkg: { name: 'foo', version: '12.0.0' },
+      root: process.cwd(),
+      nodeModulesPath: path.join(process.cwd(), 'node_modules')
+    });
+  });
+
+  it('should setup a trees hash keyed off of the type', function() {
+    expect(treeDescriptor.trees.app).to.eql('foo');
+  });
+
+  it('should hold an array of tree types', function() {
+    expect(treeDescriptor._treeTypes).to.deep.eql(['app']);
+  });
+
+  it('should update the existing instance', function() {
+    var newDesc = new TreeDescriptor({
+      tree: 'bizz',
+      treeType: 'addon',
+      packageName: 'foo',
+      name: 'fizzpoo',
+      srcDir: '/',
+      pkg: { name: 'foo', version: '12.0.0' },
+      root: process.cwd(),
+      nodeModulesPath: path.join(process.cwd(), 'node_modules')
+    });
+
+    treeDescriptor.update(newDesc);
+    expect(treeDescriptor._treeTypes).to.deep.eql(['app', 'addon']);
+    expect(treeDescriptor.trees.app).to.deep.eql('foo');
+    expect(treeDescriptor.trees.addon).to.deep.eql('bizz');
+  });
+
+  it('should merge the trees if it is updated a tree of the same type exists4', function() {
+    var newDesc = new TreeDescriptor({
+      tree: 'bizz',
+      treeType: 'app',
+      packageName: 'foo',
+      name: 'fizzpoo',
+      srcDir: '/',
+      pkg: { name: 'foo', version: '12.0.0' },
+      root: process.cwd(),
+      nodeModulesPath: path.join(process.cwd(), 'node_modules')
+    });
+
+    treeDescriptor.update(newDesc);
+    expect(treeDescriptor.trees.app.inputTrees).to.deep.eql(['foo', 'bizz']);
+  });
+});


### PR DESCRIPTION
Prior to this commit it was extremely non-obvious on how metadata was
schleped around. This commit introduces the concept of a tree descriptor
model which holds meta data about packages that eventually manifest
themselves in trees.

There is still the concept of holding the trees seperate as long as
possible, but now we have better ways of accessing those trees when we
need them.
